### PR TITLE
Joule shield with ADC detection

### DIFF
--- a/src/i2c/i2c.c
+++ b/src/i2c/i2c.c
@@ -77,9 +77,6 @@ mraa_i2c_init_internal(mraa_adv_func_t* advance_func, unsigned int bus)
 {
     mraa_result_t status = MRAA_SUCCESS;
 
-    if (advance_func == NULL)
-        return NULL;
-
     mraa_i2c_context dev = (mraa_i2c_context) calloc(1, sizeof(struct _i2c));
     if (dev == NULL) {
         syslog(LOG_CRIT, "i2c%i_init: Failed to allocate memory for context", bus);

--- a/src/x86/intel_joule_expansion.c
+++ b/src/x86/intel_joule_expansion.c
@@ -185,6 +185,15 @@ mraa_joule_expansion_board()
     b->spi_bus[4].bus_id = 32765;
     b->spi_bus[4].slave_s = 2;
 
+    b->uart_dev_count = 2;
+    b->def_uart_dev = 0;
+    b->uart_dev[0].device_path = "/dev/ttyS0";
+    b->uart_dev[0].rx = 68;
+    b->uart_dev[0].tx = 7;    
+    b->uart_dev[1].device_path = "/dev/ttyS1";
+    b->uart_dev[1].rx = 24;
+    b->uart_dev[1].tx = 22;
+
     // Aio shield detection
     // Only if i2c_designware.0 was successfully found
     if (i2c_aio_bus != -1) {

--- a/src/x86/intel_joule_expansion.c
+++ b/src/x86/intel_joule_expansion.c
@@ -245,7 +245,8 @@ mraa_joule_expansion_board()
 
                         // max sample rate and 6.144 V reference
                         // additional aio functions can be added to make up for loss of precision at 3V3, 5V, etc
-                        for (int i = 0; i < b->aio_count; i++) {
+                        int i;
+                        for (i = 0; i < b->aio_count; i++) {
                             snprintf(command, 128, "echo 3300 >/sys/bus/iio/devices/iio:device0/in_voltage%d_sampling_frequency", i);
                             system(command);
                             snprintf(command, 128, "echo 3 >/sys/bus/iio/devices/iio:device0/in_voltage%d_scale", i);
@@ -279,7 +280,8 @@ mraa_joule_expansion_board()
 
                         // max sample rate and 6.144 V reference
                         // additional aio functions can be added to make up for loss of precision at 3V3, 5V, etc
-                        for (int i = 0; i < b->aio_count; i++) {
+                        int i;
+                        for (i = 0; i < b->aio_count; i++) {
                             snprintf(command, 128, "echo 860 >/sys/bus/iio/devices/iio:device%d/in_voltage%d_sampling_frequency", i / 4, i % 4);
                             system(command);
                             snprintf(command, 128, "echo 3 >/sys/bus/iio/devices/iio:device%d/in_voltage%d_scale", i / 4, i % 4);

--- a/src/x86/intel_joule_expansion.c
+++ b/src/x86/intel_joule_expansion.c
@@ -109,22 +109,6 @@ mraa_joule_expansion_board()
         b->i2c_bus_count++;
     }
 
-    i2c_bus_num = mraa_find_i2c_bus_pci("0000:00", "0000:00:17.1", "i2c_designware.5");
-    if (i2c_bus_num != -1) {
-        b->i2c_bus[b->i2c_bus_count].bus_id = i2c_bus_num;
-        b->i2c_bus[b->i2c_bus_count].sda = 15;
-        b->i2c_bus[b->i2c_bus_count].scl = 17;
-        b->i2c_bus_count++;
-    }
-
-    i2c_bus_num = mraa_find_i2c_bus_pci("0000:00", "0000:00:17.2", "i2c_designware.6");
-    if (i2c_bus_num != -1) {
-        b->i2c_bus[b->i2c_bus_count].bus_id = i2c_bus_num;
-        b->i2c_bus[b->i2c_bus_count].sda = 19;
-        b->i2c_bus[b->i2c_bus_count].scl = 21;
-        b->i2c_bus_count++;
-    }
-
     i2c_bus_num = mraa_find_i2c_bus_pci("0000:00", "0000:00:16.1", "i2c_designware.1");
     if (i2c_bus_num != -1) {
         b->i2c_bus[b->i2c_bus_count].bus_id = i2c_bus_num;
@@ -138,6 +122,22 @@ mraa_joule_expansion_board()
         b->i2c_bus[b->i2c_bus_count].bus_id = i2c_bus_num;
         b->i2c_bus[b->i2c_bus_count].sda = 75;
         b->i2c_bus[b->i2c_bus_count].scl = 77;
+        b->i2c_bus_count++;
+    }
+
+    i2c_bus_num = mraa_find_i2c_bus_pci("0000:00", "0000:00:17.1", "i2c_designware.5");
+    if (i2c_bus_num != -1) {
+        b->i2c_bus[b->i2c_bus_count].bus_id = i2c_bus_num;
+        b->i2c_bus[b->i2c_bus_count].sda = 15;
+        b->i2c_bus[b->i2c_bus_count].scl = 17;
+        b->i2c_bus_count++;
+    }
+
+    i2c_bus_num = mraa_find_i2c_bus_pci("0000:00", "0000:00:17.2", "i2c_designware.6");
+    if (i2c_bus_num != -1) {
+        b->i2c_bus[b->i2c_bus_count].bus_id = i2c_bus_num;
+        b->i2c_bus[b->i2c_bus_count].sda = 19;
+        b->i2c_bus[b->i2c_bus_count].scl = 21;
         b->i2c_bus_count++;
     }
 


### PR DESCRIPTION
Description pretty much sums it up. If you have a Grove or DFRobot Shield for Joule and are running the latest kernel, this will detect it and load the appropriate IIO driver, configure it, and finally, add the AIO pins to the pinmap.

A couple of other minor changes:
 - reordered I2C buses
 - added UART buses + device paths