### PR TITLE
CMake: Bump min version to 3.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
-cmake_minimum_required (VERSION 2.8.11)
+cmake_minimum_required (VERSION 3.1)
 project (mraa C CXX)
+
+# Use the CMake 3.1 means to set the CXX standard
+set (CMAKE_CXX_STANDARD 11)
 
 FIND_PACKAGE (Threads REQUIRED)
 
@@ -73,17 +76,6 @@ foreach (flag ${MRAA_BOTH_WARNING_FLAGS} ${MRAA_CXX_WARNING_FLAGS})
     message (WARNING "C++ compiler does not support flag \"${flag}\"")
   endif ()
 endforeach ()
-
-# This function adds the c++11 flag to a c++ target (if supported)
-function(use_cxx_11 targetname)
-  include(CheckCXXCompilerFlag)
-  CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
-  if (COMPILER_SUPPORTS_CXX11)
-    set_target_properties(${targetname} PROPERTIES COMPILE_FLAGS "-std=c++11")
-  else()
-    message(FATAL_ERROR "Target '${targetname}' requires c++11 which is not supported by this compiler")
-  endif()
-endfunction()
 
 # Set CMAKE_INSTALL_LIBDIR if not defined
 include(GNUInstallDirs)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -51,9 +51,6 @@ if (DETECTED_ARCH STREQUAL "MOCK")
     target_include_directories(test_unit_ioinit_hpp PRIVATE "${CMAKE_SOURCE_DIR}/api")
     gtest_add_tests(test_unit_ioinit_hpp "" api/mraa_initio_hpp_unit.cxx)
     list(APPEND GTEST_UNIT_TEST_TARGETS test_unit_ioinit_hpp)
-
-    # The initio C++ header requires c++11
-    use_cxx_11(test_unit_ioinit_hpp)
 endif()
 
 # Add a target for all unit tests


### PR DESCRIPTION
Removed function for setting c++11 standard in favor of using CMake 3.1
global:

set (CMAKE_CXX_STANDARD 11)

Signed-off-by: Noel Eck <noel.eck@intel.com>