### PR TITLE
Changing CMP0078 to OLD if cmake version is greater than 3.13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,10 @@ else ()
   set (CMAKE_C_STANDARD 99)
 endif ()
 
+if (CMAKE_VERSION VERSION_GREATER "3.13")
+  cmake_policy(SET CMP0078 OLD)
+endif ()
+
 ###############################################################################
 # Detect supported warning flags
 # Modified from work By Dan Liew (fpbench - MIT)


### PR DESCRIPTION
Proposed by Gérard Vidal gerard.vidal@ens-lyon.fr
ENS de Lyon IFÉ
Add test in CMakefiles.txt on cmake version
If version > 3.13 set value OLD to CMP0078
This is proposed because the compilation of mraa yields an mraa module that cannot be imported in python3
Signed-off-by: Gérard Vidal gerard.vidal@ens-lyon.fr