### PR TITLE
Added Raspberry Pi 4 1GB 2GB and 4GB to the list of detected platforms

### DIFF
--- a/include/arm/raspberry_pi.h
+++ b/include/arm/raspberry_pi.h
@@ -41,6 +41,7 @@ extern "C" {
 #define MRAA_RASPBERRY_PI_ZERO_W_PINCOUNT 41
 #define MRAA_RASPBERRY_PI3_B_PLUS_PINCOUNT 41
 #define MRAA_RASPBERRY_PI3_A_PLUS_PINCOUNT 41
+#define MRAA_RASPBERRY_PI4_B_PINCOUNT 41
 
 mraa_board_t *
         mraa_raspberry_pi();

--- a/src/arm/raspberry_pi.c
+++ b/src/arm/raspberry_pi.c
@@ -45,6 +45,7 @@
 #define PLATFORM_NAME_RASPBERRY_PI_ZERO_W "Raspberry Pi Zero W"
 #define PLATFORM_NAME_RASPBERRY_PI3_B_PLUS "Raspberry Pi 3 Model B+"
 #define PLATFORM_NAME_RASPBERRY_PI3_A_PLUS "Raspberry Pi 3 Model A+"
+#define PLATFORM_NAME_RASPBERRY_PI4_B "Raspberry Pi 4 Model B"
 #define PLATFORM_RASPBERRY_PI_B_REV_1 1
 #define PLATFORM_RASPBERRY_PI_A_REV_2 2
 #define PLATFORM_RASPBERRY_PI_B_REV_2 3
@@ -57,6 +58,7 @@
 #define PLATFORM_RASPBERRY_PI_ZERO_W 10
 #define PLATFORM_RASPBERRY_PI3_B_PLUS 11
 #define PLATFORM_RASPBERRY_PI3_A_PLUS 12
+#define PLATFORM_RASPBERRY_PI4_B 13
 #define MMAP_PATH "/dev/mem"
 #define BCM2835_PERI_BASE 0x20000000
 #define BCM2836_PERI_BASE 0x3f000000
@@ -519,6 +521,13 @@ mraa_raspberry_pi()
                     b->phy_pin_count = MRAA_RASPBERRY_PI3_A_PLUS_PINCOUNT;
                     peripheral_base = BCM2837_PERI_BASE;
                     block_size = BCM2837_BLOCK_SIZE;
+                } else if (strstr(line, "a03111") || strstr(line, "b03111") ||
+                    strstr(line, "c03111")) {
+                    b->platform_name = PLATFORM_NAME_RASPBERRY_PI4_B;
+                    platform_detected = PLATFORM_RASPBERRY_PI4_B;
+                    b->phy_pin_count = MRAA_RASPBERRY_PI4_B_PINCOUNT;
+                    peripheral_base = BCM2837_PERI_BASE;
+                    block_size = BCM2837_BLOCK_SIZE;
                 } else {
                     b->platform_name = PLATFORM_NAME_RASPBERRY_PI_B_REV_1;
                     platform_detected = PLATFORM_RASPBERRY_PI_B_REV_1;
@@ -589,6 +598,10 @@ mraa_raspberry_pi()
             b->platform_name = PLATFORM_NAME_RASPBERRY_PI3_A_PLUS;
             platform_detected = PLATFORM_RASPBERRY_PI3_A_PLUS;
             b->phy_pin_count = MRAA_RASPBERRY_PI3_A_PLUS_PINCOUNT;
+        } else if (mraa_file_contains(compatible_path, "raspberrypi,4-model-b")) {
+            b->platform_name = PLATFORM_NAME_RASPBERRY_PI4_B;
+            platform_detected = PLATFORM_RASPBERRY_PI4_B;
+            b->phy_pin_count = MRAA_RASPBERRY_PI4_B_PINCOUNT;
         }
     }
 
@@ -857,7 +870,8 @@ mraa_raspberry_pi()
         (platform_detected == PLATFORM_RASPBERRY_PI_ZERO) ||
         (platform_detected == PLATFORM_RASPBERRY_PI_ZERO_W) ||
         (platform_detected == PLATFORM_RASPBERRY_PI3_B_PLUS) ||
-        (platform_detected == PLATFORM_RASPBERRY_PI3_A_PLUS)) {
+        (platform_detected == PLATFORM_RASPBERRY_PI3_A_PLUS) ||
+        (platform_detected == PLATFORM_RASPBERRY_PI4_B)) {
 
         strncpy(b->pins[27].name, "ID_SD", MRAA_PIN_NAME_SIZE);
         b->pins[27].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };


### PR DESCRIPTION
Signed-off-by: Chuck Duey <cduey@msn.com>
I got all 3 versions of the Pi 4 to be detected (1GB, 2GB, 4GB have different revision codes).  If there is a better version available please put in a PR. This only enables the standard overlay for the pin mapping.  The Pi 4 has some different ones available, if someone knows these, please put it in.  I ran tests on the existing code for Pi 3 B+ and it work properly on the Pi 4 B boards.  Also did a regression test on the Pi version detection all the way back to a Pi B.
Starting from a fresh version:
sudo apt-get update
sudo apt-get install cmake automake libpcre3-dev byacc flex swig3.0
git clone 
cd mraa
mkdir build
cd build
cmake -D BUILDSWIGNODE=off -D CMAKE_INSTALL_PREFIX=/usr ..
make
sudo make install
Then the regression test results:
Pi 4 1GB
Version v2.0.0-38-g2f3732d on Raspberry Pi 4 Model B
Revision	: a03111

Pi 4 2GB
Version v2.0.0-38-g2f3732d on Raspberry Pi 4 Model B
Revision	: b03111

Pi 3 A+ 512MB
Version v2.0.0-38-g2f3732d on Raspberry Pi 3 Model A+
Revision	: 9020e0

Pi 3 B+ 1GB
Version v2.0.0-38-g2f3732d on Raspberry Pi 3 Model B+
Revision	: a020d3

Pi 3 B  1GB
Version v2.0.0-38-g2f3732d on Raspberry Pi 3 Model B
Revision	: a22082

Pi 2 B 1GB
Version v2.0.0-38-g2f3732d on Raspberry Pi 2 Model B Rev 1
Revision	: a01041

Pi A+ 256MB
Version v2.0.0-38-g2f3732d on Raspberry Pi Model A+ Rev 1
Revision	: 0012

Pi B+ 512MB
Version v2.0.0-38-g2f3732d on Raspberry Pi Model B+ Rev 1
Revision	: 0010

Pi B 512MB
Version v2.0.0-38-g2f3732d on Raspberry Pi Model B Rev 2
Revision	: 000e

nJoy