### PR TITLE
fixed rockpi4 pwm issue

### DIFF
--- a/src/arm/rockpi4.c
+++ b/src/arm/rockpi4.c
@@ -130,7 +130,11 @@ mraa_rockpi4()
     }
 
     b->pins[11].pwm.parent_id = 0;
+    b->pins[11].pwm.mux_total = 0;
+    b->pins[11].pwm.pinmap = 0;
     b->pins[13].pwm.parent_id = 1;
+    b->pins[13].pwm.mux_total = 0;
+    b->pins[13].pwm.pinmap = 0;
 
     b->aio_count = MRAA_ROCKPI4_AIO_COUNT;
     b->adc_raw = 10;


### PR DESCRIPTION
somebody test rockpi4b pwm with python script,but he got some error message following:
Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
   File "/usr/local/lib/python2.7/dist-packages/mraa.py", line 1103, in __init__
     this = _mraa.new_Pwm(pin, owner, chipid)
ValueError: Error initialising PWM on pin

The reason for this problem is that some member variables isn't initialized