### PR TITLE
jsstub: Add winston as explicit dependency for mraaStub npm package

### DIFF
--- a/jsstub/package.json
+++ b/jsstub/package.json
@@ -25,6 +25,9 @@
     "url": "https://github.com/intel-iot-devkit/mraa/issues"
   },
   "homepage": "https://github.com/intel-iot-devkit/mraa#readme",
+  "dependencies": {
+    "winston": "0.8.3"
+  },
   "devDependencies": {
     "expect.js": "^0.3.1",
     "grunt": "^1.0.1",


### PR DESCRIPTION
The `mraaStub` npm package uses `winston` for logging, but it doesn't explicitly depend on it. This was breaking our build. This being node, the obvious workaround is to add `winston` as a dependency in our own `package.json`. We've done this for now, but we don't actually use it in our own code.

I'm aware that I've specified a really old version of `winston`, but it's one that I'm 100% sure works with `mraaStub`. If anyone's keen on testing what the latest compatible version is, that would of course be preferable, but in the mean time be advised that this one works fine