### PR TITLE
include: Declare gVERSION global as 'extern'.

### DIFF
--- a/include/version.h
+++ b/include/version.h
@@ -11,8 +11,8 @@
 extern "C" {
 #endif
 
-const char* gVERSION;
-const char* gVERSION_SHORT;
+extern const char* gVERSION;
+extern const char* gVERSION_SHORT;
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Fixes build with '-fno-common'.