### PR TITLE
Detect RPi 4B Rev 1.2

### DIFF
--- a/src/arm/raspberry_pi.c
+++ b/src/arm/raspberry_pi.c
@@ -505,7 +505,7 @@ mraa_raspberry_pi()
                     peripheral_base = BCM2837_PERI_BASE;
                     block_size = BCM2837_BLOCK_SIZE;
                 } else if (strstr(line, "a03111") || strstr(line, "b03111") ||
-                    strstr(line, "c03111")) {
+                    strstr(line, "c03111") || strstr(line, "c03112")) {
                     b->platform_name = PLATFORM_NAME_RASPBERRY_PI4_B;
                     platform_detected = PLATFORM_RASPBERRY_PI4_B;
                     b->phy_pin_count = MRAA_RASPBERRY_PI4_B_PINCOUNT;


### PR DESCRIPTION
RPi 4B Rev 1.2 has `Revision	: c03112` in `/proc/cpuinfo` instead of `c03111`.