### PR TITLE
Added V1.2 for Pi 4 1GB, 2GB and 4GB

### DIFF
--- a/src/arm/raspberry_pi.c
+++ b/src/arm/raspberry_pi.c
@@ -504,8 +504,9 @@ mraa_raspberry_pi()
                     b->phy_pin_count = MRAA_RASPBERRY_PI3_A_PLUS_PINCOUNT;
                     peripheral_base = BCM2837_PERI_BASE;
                     block_size = BCM2837_BLOCK_SIZE;
-                } else if (strstr(line, "a03111") || strstr(line, "b03111") ||
-                    strstr(line, "c03111")) {
+                } else if (strstr(line, "a03111") || strstr(line, "a03112") ||
+                    strstr(line, "b03111") || strstr(line, "b03112") ||
+                    strstr(line, "c03111") || strstr(line, "c03112")) {
                     b->platform_name = PLATFORM_NAME_RASPBERRY_PI4_B;
                     platform_detected = PLATFORM_RASPBERRY_PI4_B;
                     b->phy_pin_count = MRAA_RASPBERRY_PI4_B_PINCOUNT;

--- a/src/arm/raspberry_pi.c
+++ b/src/arm/raspberry_pi.c
@@ -504,7 +504,7 @@ mraa_raspberry_pi()
                     b->phy_pin_count = MRAA_RASPBERRY_PI3_A_PLUS_PINCOUNT;
                     peripheral_base = BCM2837_PERI_BASE;
                     block_size = BCM2837_BLOCK_SIZE;
-                } else if (strstr(line, "a03111") || strstr(line, "a03112") ||
+                } else if (strstr(line, "a03111") ||
                     strstr(line, "b03111") || strstr(line, "b03112") ||
                     strstr(line, "c03111") || strstr(line, "c03112")) {
                     b->platform_name = PLATFORM_NAME_RASPBERRY_PI4_B;


### PR DESCRIPTION
Used latest NOOBS 3.3.1 to build from.
 sudo apt update
 sudo apt-get install cmake automake libpcre3-dev byacc flex swig3.0
 git clone https://github.com/Chuckduey/mraa.git
 cd mraa
 mkdir build
 cmake -DBUILDSWIGNODE=OFF -DCMAKE_INSTALL_PREFIX=/usr ..
 make
 sudo make install
 sudo ldconfig
 mraa-gpio version
 Ran regression tests on new Pi 4,  older Pi 4, and Pi 3 versions worked fine.
nJoy

Signed-off-by: Chuckduey <cduey@msn.com>