### PR TITLE
CMakeLists.txt: add ENABLECXX option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required (VERSION 2.8.11)
-project (mraa C CXX)
+project (mraa C)
 
 FIND_PACKAGE (Threads REQUIRED)
 
@@ -10,6 +10,8 @@ if (CMAKE_VERSION VERSION_LESS "3.1")
 else ()
   set (CMAKE_C_STANDARD 99)
 endif ()
+
+option (BUILDCPP "Enable C++ (needed by FTDI4222 and tests)" ON)
 
 ###############################################################################
 # Detect supported warning flags
@@ -33,15 +35,18 @@ set (MRAA_C_WARNING_FLAGS
   -Werror=missing-parameter-type
 )
 
-# Warning flags for the C++ compiler only
-set (MRAA_CXX_WARNING_FLAGS
-  -Wnon-virtual-dtor
-  -Woverloaded-virtual
-  -Wreorder
-)
-
 include (CheckCCompilerFlag)
-include (CheckCXXCompilerFlag)
+if (BUILDCPP)
+  # Warning flags for the C++ compiler only
+  set (MRAA_CXX_WARNING_FLAGS
+    -Wnon-virtual-dtor
+    -Woverloaded-virtual
+    -Wreorder
+  )
+
+  enable_language (CXX)
+  include (CheckCXXCompilerFlag)
+endif ()
 function (MRAA_SANITIZE_FLAG_NAME OUTPUT_VAR FLAG)
   string (REPLACE "-" "_" SANITIZED_FLAG_NAME "${FLAG}")
   string (REPLACE "/" "_" SANITIZED_FLAG_NAME "${SANITIZED_FLAG_NAME}")
@@ -62,28 +67,30 @@ foreach (flag ${MRAA_BOTH_WARNING_FLAGS} ${MRAA_C_WARNING_FLAGS})
   endif ()
 endforeach ()
 
-# Globally set C++ compiler warning flags that are supported and emit
-# a warning about unsupported flags
-foreach (flag ${MRAA_BOTH_WARNING_FLAGS} ${MRAA_CXX_WARNING_FLAGS})
-  MRAA_SANITIZE_FLAG_NAME (SANITIZED_FLAG_NAME "${flag}")
-  CHECK_CXX_COMPILER_FLAG ("${flag}" HAS_CXX_${SANITIZED_FLAG_NAME})
-  if (HAS_CXX_${SANITIZED_FLAG_NAME})
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${flag}")
-  else ()
-    message (WARNING "C++ compiler does not support flag \"${flag}\"")
-  endif ()
-endforeach ()
+if (BUILDCPP)
+  # Globally set C++ compiler warning flags that are supported and emit
+  # a warning about unsupported flags
+  foreach (flag ${MRAA_BOTH_WARNING_FLAGS} ${MRAA_CXX_WARNING_FLAGS})
+    MRAA_SANITIZE_FLAG_NAME (SANITIZED_FLAG_NAME "${flag}")
+    CHECK_CXX_COMPILER_FLAG ("${flag}" HAS_CXX_${SANITIZED_FLAG_NAME})
+    if (HAS_CXX_${SANITIZED_FLAG_NAME})
+      set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${flag}")
+    else ()
+      message (WARNING "C++ compiler does not support flag \"${flag}\"")
+    endif ()
+  endforeach ()
 
-# This function adds the c++11 flag to a c++ target (if supported)
-function(use_cxx_11 targetname)
-  include(CheckCXXCompilerFlag)
-  CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
-  if (COMPILER_SUPPORTS_CXX11)
-    set_target_properties(${targetname} PROPERTIES COMPILE_FLAGS "-std=c++11")
-  else()
-    message(FATAL_ERROR "Target '${targetname}' requires c++11 which is not supported by this compiler")
-  endif()
-endfunction()
+  # This function adds the c++11 flag to a c++ target (if supported)
+  function(use_cxx_11 targetname)
+    include(CheckCXXCompilerFlag)
+    CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
+    if (COMPILER_SUPPORTS_CXX11)
+      set_target_properties(${targetname} PROPERTIES COMPILE_FLAGS "-std=c++11")
+    else()
+      message(FATAL_ERROR "Target '${targetname}' requires c++11 which is not supported by this compiler")
+    endif()
+  endfunction()
+endif()
 
 # Set CMAKE_INSTALL_LIBDIR if not defined
 include(GNUInstallDirs)

--- a/src/java/CMakeLists.txt
+++ b/src/java/CMakeLists.txt
@@ -16,7 +16,9 @@ include_directories (
 set_source_files_properties (mraajava.i PROPERTIES SWIG_FLAGS ";-package;mraa;-I${CMAKE_BINARY_DIR}/src")
 set_source_files_properties (mraajava.i PROPERTIES CPLUSPLUS ON)
 
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive -DJAVACALLBACK")
+if (BUILDCPP)
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive -DJAVACALLBACK")
+endif()
 set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DJAVACALLBACK")
 
 if (NOT DEFINED ENV{JAVA_HOME_NATIVE})

--- a/src/javascript/CMakeLists.txt
+++ b/src/javascript/CMakeLists.txt
@@ -36,25 +36,27 @@ set_target_properties (mraajs PROPERTIES
 )
 
 message (STATUS "INFO - swig Version ${SWIG_VERSION}")
-message (STATUS "INFO - CXX compiler Version ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}")
+if (BUILDCPP)
+  message (STATUS "INFO - CXX compiler Version ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}")
 
-if (${V8_VERSION_MAJOR} GREATER 3)
-  message (STATUS "INFO - Using V8 version > 3 so requiring C++11 compiler")
-  # Node 0.12.x V8 engine major version is '3'.
-  # Node 2.1.0  V8 engine major version is '4'.
-  set_property (TARGET mraajs PROPERTY CXX_STANDARD 11)
-  set_property (TARGET mraajs PROPERTY CXX_STANDARD_REQUIRED ON)
-  if (CMAKE_VERSION VERSION_LESS "3.1")
-    message (WARNING "Need to use CMAKE version 3.1+, but it is ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}.${CMAKE_PATCH_VERSION}, using a workaround.")
-    if (CMAKE_COMPILER_IS_GNUCXX)
-      if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.7")
-        message (FATAL_ERROR "GNU gcc compiler is also too old (need 4.7+, but ${CMAKE_CXX_COMPILER_VERSION}) and does not support C++11 standard.")
+  if (${V8_VERSION_MAJOR} GREATER 3)
+    message (STATUS "INFO - Using V8 version > 3 so requiring C++11 compiler")
+    # Node 0.12.x V8 engine major version is '3'.
+    # Node 2.1.0  V8 engine major version is '4'.
+    set_property (TARGET mraajs PROPERTY CXX_STANDARD 11)
+    set_property (TARGET mraajs PROPERTY CXX_STANDARD_REQUIRED ON)
+    if (CMAKE_VERSION VERSION_LESS "3.1")
+      message (WARNING "Need to use CMAKE version 3.1+, but it is ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}.${CMAKE_PATCH_VERSION}, using a workaround.")
+      if (CMAKE_COMPILER_IS_GNUCXX)
+        if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.7")
+          message (FATAL_ERROR "GNU gcc compiler is also too old (need 4.7+, but ${CMAKE_CXX_COMPILER_VERSION}) and does not support C++11 standard.")
+        endif ()
+        set (MRAA_CXX11_WORKAROUND_OPTION "-std=gnu++11")
+      else ()
+        set (MRAA_CXX11_WORKAROUND_OPTION "-std=c++11")
       endif ()
-      set (MRAA_CXX11_WORKAROUND_OPTION "-std=gnu++11")
-    else ()
-      set (MRAA_CXX11_WORKAROUND_OPTION "-std=c++11")
+      set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${MRAA_CXX11_WORKAROUND_OPTION} ")
     endif ()
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${MRAA_CXX11_WORKAROUND_OPTION} ")
   endif ()
 endif ()
 


### PR DESCRIPTION
C++ is a mandatory dependency since version 1.4.0 and https://github.com/eclipse/mraa/commit/122cab1f1e53b7c9c7cd82905b962071f9bad9dc

As a result, build on embedded toolchains that do not support C++ fails
on:

```
CMake Error at CMakeLists.txt:2 (project):
  The CMAKE_CXX_COMPILER:

    /home/naourr/work/instance-1/output-1/per-package/mraa/host/bin/arm-linux-g++

  is not a full path to an existing compiler tool.
```
Fixes:
 - http://autobuild.buildroot.org/results/31086422e03611c16ab59c4418e3669b580bc0c0

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>