### PR TITLE
Added Pi 4 8GB to Pi 4 section

### DIFF
--- a/src/arm/raspberry_pi.c
+++ b/src/arm/raspberry_pi.c
@@ -506,7 +506,8 @@ mraa_raspberry_pi()
                     block_size = BCM2837_BLOCK_SIZE;
                 } else if (strstr(line, "a03111") || 
                     strstr(line, "b03111") || strstr(line, "b03112") ||
-                    strstr(line, "c03111") || strstr(line, "c03112")) {
+                    strstr(line, "c03111") || strstr(line, "c03112") ||
+                    strstr(line, "d03114")) {
                     b->platform_name = PLATFORM_NAME_RASPBERRY_PI4_B;
                     platform_detected = PLATFORM_RASPBERRY_PI4_B;
                     b->phy_pin_count = MRAA_RASPBERRY_PI4_B_PINCOUNT;


### PR DESCRIPTION
Signed-off-by: Chuckduey <cduey@msn.com>
Raspberry Pi came out with a new version of Pi 4 with 8GB of ram and updated the revision to V1.4 . CPU Info code: d03114   This code adds a check for the 8GB revision in the Pi 4 Section. 
a = 1GB
b = 2GB
c = 4GB
d = 8GB
