### PR TITLE
Allow GPIO ISR and state read on UP2

### DIFF
--- a/src/x86/up2.c
+++ b/src/x86/up2.c
@@ -101,7 +101,7 @@ mraa_up2_board()
     b->platform_version = PLATFORM_VERSION;
     b->phy_pin_count = MRAA_UP2_PINCOUNT;
     b->gpio_count = MRAA_UP2_GPIOCOUNT;
-    b->chardev_capable = 1;
+    b->chardev_capable = 0;
 
     b->pins = (mraa_pininfo_t*) malloc(sizeof(mraa_pininfo_t) * MRAA_UP2_PINCOUNT);
     if (b->pins == NULL) {


### PR DESCRIPTION
This PR addresses #937.

By setting ```chardev_capable = 0``` it is possible to activate ISR on a pin AND read the state of the pin out.