### PR TITLE
docs: fix simple typo, repeately -> repeatedly

### DIFF
--- a/examples/c/pwm.c
+++ b/examples/c/pwm.c
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: MIT
  *
  * Example usage: Generates PWM signal of period 200us with variable dutycyle
- *                repeately. Press Ctrl+C to exit
+ *                repeatedly. Press Ctrl+C to exit
  */
 
 /* standard headers */

--- a/examples/c/spi.c
+++ b/examples/c/spi.c
@@ -6,7 +6,7 @@
  *
  * SPDX-License-Identifier: MIT
  *
- * Example usage: Display set of patterns on MAX7219 repeately.
+ * Example usage: Display set of patterns on MAX7219 repeatedly.
  *                Press Ctrl+C to exit
  */
 


### PR DESCRIPTION
There is a small typo in examples/c/pwm.c, examples/c/spi.c.

Should read `repeatedly` rather than `repeately`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md