### PR TITLE
Added Raspberry Pi 400 to platforms

### DIFF
--- a/include/arm/raspberry_pi.h
+++ b/include/arm/raspberry_pi.h
@@ -25,6 +25,7 @@ extern "C" {
 #define MRAA_RASPBERRY_PI3_B_PLUS_PINCOUNT 41
 #define MRAA_RASPBERRY_PI3_A_PLUS_PINCOUNT 41
 #define MRAA_RASPBERRY_PI4_B_PINCOUNT 41
+#define MRAA_RASPBERRY_PI_400_PINCOUNT 41
 
 mraa_board_t *
         mraa_raspberry_pi();

--- a/src/arm/raspberry_pi.c
+++ b/src/arm/raspberry_pi.c
@@ -29,6 +29,7 @@
 #define PLATFORM_NAME_RASPBERRY_PI3_B_PLUS "Raspberry Pi 3 Model B+"
 #define PLATFORM_NAME_RASPBERRY_PI3_A_PLUS "Raspberry Pi 3 Model A+"
 #define PLATFORM_NAME_RASPBERRY_PI4_B "Raspberry Pi 4 Model B"
+#define PLATFORM_NAME_RASPBERRY_PI_400 "Raspberry Pi 400"
 #define PLATFORM_RASPBERRY_PI_B_REV_1 1
 #define PLATFORM_RASPBERRY_PI_A_REV_2 2
 #define PLATFORM_RASPBERRY_PI_B_REV_2 3
@@ -42,6 +43,7 @@
 #define PLATFORM_RASPBERRY_PI3_B_PLUS 11
 #define PLATFORM_RASPBERRY_PI3_A_PLUS 12
 #define PLATFORM_RASPBERRY_PI4_B 13
+#define PLATFORM_RASPBERRY_PI_400 14
 #define MMAP_PATH "/dev/mem"
 #define BCM2835_PERI_BASE 0x20000000
 #define BCM2836_PERI_BASE 0x3f000000
@@ -513,6 +515,12 @@ mraa_raspberry_pi()
                     b->phy_pin_count = MRAA_RASPBERRY_PI4_B_PINCOUNT;
                     peripheral_base = BCM2837_PERI_BASE;
                     block_size = BCM2837_BLOCK_SIZE;
+                } else if (strstr(line, "c03130")) {
+                    b->platform_name = PLATFORM_NAME_RASPBERRY_PI_400;
+                    platform_detected = PLATFORM_RASPBERRY_PI_400;
+                    b->phy_pin_count = MRAA_RASPBERRY_PI_400_PINCOUNT;
+                    peripheral_base = BCM2837_PERI_BASE;
+                    block_size = BCM2837_BLOCK_SIZE;
                 } else {
                     b->platform_name = PLATFORM_NAME_RASPBERRY_PI_B_REV_1;
                     platform_detected = PLATFORM_RASPBERRY_PI_B_REV_1;
@@ -587,6 +595,10 @@ mraa_raspberry_pi()
             b->platform_name = PLATFORM_NAME_RASPBERRY_PI4_B;
             platform_detected = PLATFORM_RASPBERRY_PI4_B;
             b->phy_pin_count = MRAA_RASPBERRY_PI4_B_PINCOUNT;
+        } else if (mraa_file_contains(compatible_path, "raspberrypi,4-model-bbrcm")) {
+            b->platform_name = PLATFORM_NAME_RASPBERRY_PI_400;
+            platform_detected = PLATFORM_RASPBERRY_PI_400;
+            b->phy_pin_count = MRAA_RASPBERRY_PI_400_PINCOUNT;
         }
     }
 
@@ -856,7 +868,8 @@ mraa_raspberry_pi()
         (platform_detected == PLATFORM_RASPBERRY_PI_ZERO_W) ||
         (platform_detected == PLATFORM_RASPBERRY_PI3_B_PLUS) ||
         (platform_detected == PLATFORM_RASPBERRY_PI3_A_PLUS) ||
-        (platform_detected == PLATFORM_RASPBERRY_PI4_B)) {
+        (platform_detected == PLATFORM_RASPBERRY_PI4_B) ||
+        (platform_detected == PLATFORM_RASPBERRY_PI_400)) {
 
         strncpy(b->pins[27].name, "ID_SD", MRAA_PIN_NAME_SIZE);
         b->pins[27].capabilities = (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 0, 0 };


### PR DESCRIPTION
This adds **Raspberry Pi 400** Desktop to src/arm/raspberrypi.c and include/arm/raspberrypi.h as mentioned in #1050 
This is very much like the Pi 4 but the format of the CPU card is very different. A cable can be used to connect to the 40 pin header on the back of the keyboard.  The pinout is the same as the Pi 4.
   
 For Raspberry Pi 400 Desktop Raspberry Pi OS Dec. 2nd 2020 and newer is required.

to Install and build mraa:

sudo apt-get install cmake automake libpcre3-dev byacc flex swig3.0
git clone https://github.com/Chuckduey/mraa.git
cd mraa
mkdir build
cd build
cmake -DCMAKE_INSTALL_PREFIX=/usr ..
make
sudo make install
mraa-gpio version
mraa-gpio list

Regression testing:
Revision	: c03130
Version v2.2.0 on Raspberry Pi 400

Revision	: d03114
Version v2.2.0 on Raspberry Pi 4 Model B

Revision	: a03111
Version v2.2.0 on Raspberry Pi 4 Model B

Revision	: a22082
Version v2.2.0 on Raspberry Pi 3 Model B

Signed-off-by: Chuckduey <cduey@msn.com>