### PR TITLE
UART related fixes and cleanups

### DIFF
--- a/api/mraa/uart.h
+++ b/api/mraa/uart.h
@@ -171,8 +171,8 @@ const char* mraa_uart_get_dev_path(mraa_uart_context dev);
  * @param databits pointer to an integer to contain the number databits (5--8)
  * @param stopbits pointer to an integer to contain the number stopbits (1--2)
  * @param parity will contain the current parity mode
- * @param rtscts will point to non-zero if CTS/RTS flow control is enabled, zero otherwise
- * @param xonxoff will point to a non-zero value if xon/xoff flow control is enabled
+ * @param rtscts will point to true if CTS/RTS flow control is enabled
+ * @param xonxoff will point to a true if xon/xoff flow control is enabled
  * @return result
  */
 mraa_result_t
@@ -183,8 +183,8 @@ mraa_uart_settings(int index,
     int* databits,
     int* stopbits,
     mraa_uart_parity_t* parity,
-    unsigned int* rtscts,
-    unsigned int* xonxoff);
+    mraa_boolean_t* rtscts,
+    mraa_boolean_t* xonxoff);
 
 /**
  * Destroy a mraa_uart_context

--- a/examples/c/uart_advanced.c
+++ b/examples/c/uart_advanced.c
@@ -46,7 +46,6 @@ main(int argc, char** argv)
     int baudrate = 9600, stopbits = 1, databits = 8;
     mraa_uart_parity_t parity = MRAA_UART_PARITY_NONE;
     unsigned int ctsrts = FALSE, xonxoff = FALSE;
-    const char* name = NULL;
 
     /* install signal handler */
     signal(SIGINT, sig_handler);
@@ -63,8 +62,15 @@ main(int argc, char** argv)
     }
 
     /* set serial port parameters */
-    status =
-    mraa_uart_settings(-1, &dev_path, &name, &baudrate, &databits, &stopbits, &parity, &ctsrts, &xonxoff);
+    status = mraa_uart_set_baudrate(uart, baudrate);
+    if (status != MRAA_SUCCESS) {
+        goto err_exit;
+    }
+    status = mraa_uart_set_mode(uart, databits, parity, stopbits);
+    if (status != MRAA_SUCCESS) {
+        goto err_exit;
+    }
+    status = mraa_uart_set_flowcontrol(uart, xonxoff, ctsrts);
     if (status != MRAA_SUCCESS) {
         goto err_exit;
     }

--- a/src/uart/uart.c
+++ b/src/uart/uart.c
@@ -616,22 +616,18 @@ mraa_uart_set_flowcontrol(mraa_uart_context dev, mraa_boolean_t xonxoff, mraa_bo
         }
     }
 
-    // hardware flow control
-    int action = TCIOFF;
-    if (xonxoff) {
-        action = TCION;
-    }
-    if (tcflow(dev->fd, action)) {
-        return MRAA_ERROR_FEATURE_NOT_SUPPORTED;
-    }
-
-    // rtscts
     struct termios termio;
 
     // get current modes
     if (tcgetattr(dev->fd, &termio)) {
         syslog(LOG_ERR, "uart%i: set_flowcontrol: tcgetattr() failed: %s", dev->index, strerror(errno));
          return MRAA_ERROR_INVALID_RESOURCE;
+    }
+
+    if (xonxoff) {
+        termio.c_iflag |= IXON|IXOFF;
+    } else {
+        termio.c_iflag &= ~(IXON|IXOFF);
     }
 
     if (rtscts) {

--- a/src/uart/uart.c
+++ b/src/uart/uart.c
@@ -337,7 +337,7 @@ mraa_uart_stop(mraa_uart_context dev)
 }
 
 mraa_result_t
-mraa_uart_settings(int index, const char **devpath, const char **name, int* baudrate, int* databits, int* stopbits, mraa_uart_parity_t* parity, unsigned int* ctsrts, unsigned int* xonxoff) {
+mraa_uart_settings(int index, const char **devpath, const char **name, int* baudrate, int* databits, int* stopbits, mraa_uart_parity_t* parity, mraa_boolean_t* ctsrts, mraa_boolean_t* xonxoff) {
     struct termios term;
     int fd;
 
@@ -415,11 +415,11 @@ mraa_uart_settings(int index, const char **devpath, const char **name, int* baud
        }
 
        if (ctsrts != NULL) {
-           *ctsrts = term.c_cflag & CRTSCTS;
+           *ctsrts = (term.c_cflag & CRTSCTS) != 0;
        }
 
        if (xonxoff != NULL) {
-           *xonxoff = term.c_iflag & (IXON|IXOFF);
+           *xonxoff = (term.c_iflag & (IXON|IXOFF)) != 0;
        }
 
        close(fd);

--- a/tools/mraa-uart.c
+++ b/tools/mraa-uart.c
@@ -106,7 +106,7 @@ main(int argc, const char** argv) {
 
     int baudrate = 115200, stopbits = 1, databits = 8;
     mraa_uart_parity_t parity = MRAA_UART_PARITY_NONE;
-    unsigned int ctsrts = FALSE, xonxoff = FALSE;
+    mraa_boolean_t ctsrts = FALSE, xonxoff = FALSE;
     const char *name = NULL, *dev = NULL;
 
     double recieve_timeout = 0.0;


### PR DESCRIPTION
mraa_uart_set_flowcontrol was broken /wrt soft flow-control management, mraa_uart_settings used an inconsistent type for soft and hard flow-control, and finally an example code for the uart api was plain wrong.