### PR TITLE
api: Add explicit close methods to classes

### DIFF
--- a/api/mraa/aio.hpp
+++ b/api/mraa/aio.hpp
@@ -76,7 +76,18 @@ class Aio
      */
     ~Aio()
     {
+        if (m_aio != NULL) {
+            mraa_aio_close(m_aio);
+        }
+    }
+    /**
+     * Closes AIO explicitly, prior to implicit closing on object destruction
+     */
+    void
+    close()
+    {
         mraa_aio_close(m_aio);
+        m_aio = NULL;
     }
     /**
      * Read a value from the AIO pin. By default mraa will shift

--- a/api/mraa/gpio.hpp
+++ b/api/mraa/gpio.hpp
@@ -144,7 +144,18 @@ class Gpio
      */
     ~Gpio()
     {
+        if (m_gpio != NULL) {
+            mraa_gpio_close(m_gpio);
+        }
+    }
+    /**
+     * Closes Gpio explicitly, prior to implicit closing on object destruction
+     */
+    void
+    close()
+    {
         mraa_gpio_close(m_gpio);
+        m_gpio = NULL;
     }
     /**
      * Set the edge mode for ISR

--- a/api/mraa/i2c.hpp
+++ b/api/mraa/i2c.hpp
@@ -84,7 +84,19 @@ class I2c
      */
     ~I2c()
     {
+        if (m_i2c != NULL) {
+            mraa_i2c_stop(m_i2c);
+        }
+    }
+
+    /**
+     * Closes I2c explicitly, prior to implicit closing on object destruction
+     */
+    void
+    close()
+    {
         mraa_i2c_stop(m_i2c);
+        m_i2c = NULL;
     }
 
     /**

--- a/api/mraa/iio.hpp
+++ b/api/mraa/iio.hpp
@@ -131,9 +131,20 @@ class Iio
      */
     ~Iio()
     {
-        mraa_iio_close(m_iio);
+        if (m_iio != NULL) {
+            mraa_iio_close(m_iio);
+        }
     }
 
+    /**
+     * Closes Iio explicitly, prior to implicit closing on object destruction
+     */
+    void
+    close()
+    {
+        mraa_iio_close(m_iio);
+        m_iio = NULL;
+    }
 
     /**
      * Get device name

--- a/api/mraa/led.hpp
+++ b/api/mraa/led.hpp
@@ -90,7 +90,19 @@ class Led
      */
     ~Led()
     {
+        if (m_led != NULL) {
+            mraa_led_close(m_led);
+        }
+    }
+
+    /*
+     * Closes LED explicitly, prior to implicit closing on object destruction
+     */
+    void
+    close()
+    {
         mraa_led_close(m_led);
+        m_led = NULL;
     }
 
     /**

--- a/api/mraa/pwm.hpp
+++ b/api/mraa/pwm.hpp
@@ -87,7 +87,18 @@ class Pwm
      */
     ~Pwm()
     {
+        if (m_pwm != NULL) {
+            mraa_pwm_close(m_pwm);
+        }
+    }
+    /*
+     * Closes Pwm explicitly, prior to implicit closing on object destruction
+     */
+    void
+    close()
+    {
         mraa_pwm_close(m_pwm);
+        m_pwm = NULL;
     }
     /**
      * Set the output duty-cycle percentage, as a float

--- a/api/mraa/spi.hpp
+++ b/api/mraa/spi.hpp
@@ -106,7 +106,19 @@ class Spi
      */
     ~Spi()
     {
+        if (m_spi != NULL) {
+            mraa_spi_stop(m_spi);
+        }
+    }
+
+    /**
+     * Closes Spi explicitly, prior to implicit closing on object destruction
+     */
+    void
+    close()
+    {
         mraa_spi_stop(m_spi);
+        m_spi = NULL;
     }
 
     /**

--- a/api/mraa/uart.hpp
+++ b/api/mraa/uart.hpp
@@ -96,7 +96,19 @@ class Uart
      */
     ~Uart()
     {
+        if (m_uart != NULL) {
+            mraa_uart_stop(m_uart);
+        }
+    }
+
+    /*
+     * Closes Uart explicitly, prior to implicit closing on object destruction
+     */
+    void
+    close()
+    {
         mraa_uart_stop(m_uart);
+        m_uart = NULL;
     }
 
     /**

--- a/api/mraa/uart_ow.hpp
+++ b/api/mraa/uart_ow.hpp
@@ -96,7 +96,19 @@ class UartOW
      */
     ~UartOW()
     {
+        if (m_uart != NULL) {
+            mraa_uart_ow_stop(m_uart);
+        }
+    }
+
+    /*
+     * Closes UartOW explicitly, prior to implicit closing on object destruction
+     */
+    void
+    close()
+    {
         mraa_uart_ow_stop(m_uart);
+        m_uart = NULL;
     }
 
     /**


### PR DESCRIPTION
This is needed for bindings to languages which perform implicit and lazy
object cleanups. The explicit close methods allow to release resources
when they are no longer required, permitting deterministic reuse. One
example is node-red-node-intel-gpio which will use the new calls on node
closing.

Fixes #1044.