### PR TITLE
rockpi4.c: Add chardev GPIO support

### DIFF
--- a/src/arm/rockpi4.c
+++ b/src/arm/rockpi4.c
@@ -38,9 +38,8 @@ mraa_rockpi4_pininfo(mraa_board_t* board, int index, int sysfs_pin, mraa_pincapa
     vsnprintf(pininfo->name, MRAA_PIN_NAME_SIZE, fmt, arg_ptr);
 
     if( pincapabilities_t.gpio == 1 ) {
-        va_arg(arg_ptr, int);
-        pininfo->gpio.gpio_chip = va_arg(arg_ptr, int);
-        pininfo->gpio.gpio_line = va_arg(arg_ptr, int);
+        pininfo->gpio.gpio_chip = sysfs_pin / 32;
+        pininfo->gpio.gpio_line = sysfs_pin % 32;
     }
 
     pininfo->capabilities = pincapabilities_t;
@@ -124,6 +123,7 @@ mraa_rockpi4()
     b->adc_supported = 10;
     b->aio_dev[0].pin = 26;
     b->aio_non_seq = 1;
+    b->chardev_capable = 1;
 
     mraa_rockpi4_pininfo(b, 0,   -1, (mraa_pincapabilities_t){0,0,0,0,0,0,0,0}, "INVALID");
     mraa_rockpi4_pininfo(b, 1,   -1, (mraa_pincapabilities_t){1,0,0,0,0,0,0,0}, "3V3");


### PR DESCRIPTION
The recommended config for upstream kernels (arm64
defconfig) on the Radxa "mainline" kernel Wiki
does not include GPIO sysfs support, so libmraa
applications and utilies don't work out of the
box. This change marks the board as supporting the
GPIO character device interface and fixes the
group and line number assignments such that it
actually works. Performance is also noticeably
better with the chardev path.

I tested this by using mraa-gpio to toggle various
pins on the 40-pin header with a multimeter
attached, and with a program I have that that
toggles 8 GPIO pins at the same time to upload
data to another system using a parallel protocol.
On upstream/mainline kernels, chardev support is
now used. On the older 4.4 kernels from Radxa,
chardev support is not available and libmraa
gracefully falls back to sysfs.

Note another significant difference compared to
the Radxa kernels in upstream kernels is the
default devicetree must be tweaked to disable the
'i2s1' device in order to use GPIO pins 12, 35,
36, 38, and 40 via libmraa. For example, I
appended the following section:

  &i2s1 {
      status = "disabled";
  };

to arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4b.dts
to accomplish this.

Signed-off-by: James Jones <linux@theinnocuous.com>