### PR TITLE
gpio: fix incorrect assignment of *cinfos in mraa_get_chip_infos

### DIFF
--- a/src/gpio/gpio_chardev.c
+++ b/src/gpio/gpio_chardev.c
@@ -431,6 +431,8 @@ mraa_get_chip_infos(mraa_gpiod_chip_info*** cinfos)
         return -1;
     }
 
+    *cinfos = cinfo;
+
     /* Get chip info for all gpiochips present in the platform */
     for (i = 0; i < num_chips; i++) {
         cinfo[i] = mraa_get_chip_info_by_name(dirs[i]->d_name);
@@ -439,8 +441,6 @@ mraa_get_chip_infos(mraa_gpiod_chip_info*** cinfos)
             return 0;
         }
     }
-
-    *cinfos = cinfo;
 
     return num_chips;
 }


### PR DESCRIPTION
cinfos in mraa_get_chip_infos is not set in case of
mraa_get_chip_info_by_name failure which happens on access of /dev/gpiochip*
files which leads to memory free by invalid pointer in *cinfos.

As example, it can be easy recreated with non-root run of mraa-gpio:

test@iot2050-debian:~$ mraa-gpio
free(): invalid pointer
Aborted

The question is, is it right to hide the information about incorrect access to files and just don't show gpio lines? 
Or is it need to be delivered to end user with information about those files aren't being accessed?

siemens/meta-iot2050#281