### PR TITLE
mraa-gpio: return proper error codes

### DIFF
--- a/src/gpio/gpio.c
+++ b/src/gpio/gpio.c
@@ -596,7 +596,11 @@ mraa_gpio_wait_interrupt(int fds[],
 
         // do an initial read to clear interrupt
         lseek(fds[i], 0, SEEK_SET);
-        read(fds[i], &c, 1);
+        ssize_t nbytes = read(fds[i], &c, 1);
+        if (nbytes < 0) {
+            syslog(LOG_ERR, "mraa_gpio_wait_interrupt: Failed to read from poll fd");
+            return MRAA_ERROR_NO_DATA_AVAILABLE;
+        }
     }
 
 #ifdef HAVE_PTHREAD_CANCEL
@@ -614,7 +618,11 @@ mraa_gpio_wait_interrupt(int fds[],
 
     for (int i = 0; i < num_fds; ++i) {
         if (pfd[i].revents & POLLPRI) {
-            read(fds[i], &c, 1);
+            ssize_t nbytes = read(fds[i], &c, 1);
+            if (nbytes < 0) {
+                syslog(LOG_ERR, "mraa_gpio_wait_interrupt: Failed to read from poll fd");
+                return MRAA_ERROR_NO_DATA_AVAILABLE;
+            }
             events[i].id = i;
             events[i].timestamp = _mraa_gpio_get_timestamp_sysfs();
         } else
@@ -645,7 +653,11 @@ mraa_gpio_chardev_wait_interrupt(int fds[], int num_fds, mraa_gpio_events_t even
 
     for (int i = 0; i < num_fds; ++i) {
         if (pfd[i].revents & POLLIN) {
-            read(fds[i], &event_data, sizeof(event_data));
+            ssize_t nbytes = read(fds[i], &event_data, sizeof(event_data));
+            if (nbytes < 0) {
+                syslog(LOG_ERR, "mraa_gpio_chardev_wait_interrupt: Failed to read from poll fd");
+                return MRAA_ERROR_NO_DATA_AVAILABLE;
+            }
             events[i].id = i;
             events[i].timestamp = event_data.timestamp;
         } else

--- a/src/initio/initio.c
+++ b/src/initio/initio.c
@@ -57,9 +57,10 @@ mraa_tokenize_string(const char* str, const char* delims, int* num_tokens)
         if (tok == NULL) {
             break;
         }
+        size_t tok_len = strlen(tok);
         output = realloc(output, (++output_size) * sizeof(char*));
-        output[output_size - 1] = calloc(strlen(tok) + 1, sizeof(char));
-        strncpy(output[output_size - 1], tok, strlen(tok));
+        output[output_size - 1] = calloc(tok_len + 1, sizeof(char));
+        strncpy(output[output_size - 1], tok, tok_len + 1);
     }
     *num_tokens = output_size;
 
@@ -762,20 +763,21 @@ mraa_io_init(const char* strdesc, mraa_io_descriptor** desc)
             }
         } else {
             /* Here we build the leftover string. */
+            size_t descs_len = strlen(str_descs[i]);
             new_desc->leftover_str =
-            realloc(new_desc->leftover_str, sizeof(char) * (leftover_str_len + strlen(str_descs[i]) + 2));
+              realloc(new_desc->leftover_str, sizeof(char) * (leftover_str_len + descs_len) + 2);
             if (!new_desc->leftover_str) {
                 syslog(LOG_ERR, "mraa_io_init: error allocating memory for leftover string");
                 status = MRAA_ERROR_NO_RESOURCES;
                 free(new_desc);
             } else {
                 if (leftover_str_len == 0) {
-                    strncpy(new_desc->leftover_str, str_descs[i], strlen(str_descs[i]));
+                    strncpy(new_desc->leftover_str, str_descs[i], descs_len);
                 } else {
-                    strncat(new_desc->leftover_str, str_descs[i], strlen(str_descs[i]));
+                    strncat(new_desc->leftover_str, str_descs[i], leftover_str_len + descs_len);
                 }
 
-                leftover_str_len += strlen(str_descs[i]) + 1;
+                leftover_str_len += descs_len + 1;
                 new_desc->leftover_str[leftover_str_len - 1] = ',';
                 new_desc->leftover_str[leftover_str_len] = '\0';
             }

--- a/src/json/jsonplatform.c
+++ b/src/json/jsonplatform.c
@@ -601,6 +601,7 @@ mraa_init_json_platform(const char* platform_json)
     int file_lock = 0, i = 0;
     json_object* jobj_platform = NULL;
     mraa_board_t* board = NULL;
+    size_t len;
 
     // Try to lock the file for use
     if ((file_lock = open(platform_json, O_RDONLY)) == -1) {
@@ -703,14 +704,15 @@ mraa_init_json_platform(const char* platform_json)
     if (!plat->platform_name) {
         goto unsuccessful;
     } else {
-        platform_name = calloc(strlen(plat->platform_name) + 1, sizeof(char));
+        len = strlen(plat->platform_name);
+        platform_name = calloc(len + 1, sizeof(char));
     }
 
     if (platform_name == NULL) {
         syslog(LOG_ERR, "init_json_platform: Could not allocate memory for platform_name");
         goto unsuccessful;
     }
-    strncpy(platform_name, plat->platform_name, strlen(plat->platform_name) + 1);
+    strncpy(platform_name, plat->platform_name, len + 1);
 
     // We made it to the end without anything going wrong, just cleanup
     ret = MRAA_SUCCESS;

--- a/src/led/led.c
+++ b/src/led/led.c
@@ -44,7 +44,7 @@ mraa_led_get_brightfd(mraa_led_context dev)
     snprintf(buf, MAX_SIZE, "%s/%s", dev->led_path, "brightness");
     dev->bright_fd = open(buf, O_RDWR);
     if (dev->bright_fd == -1) {
-        syslog(LOG_ERR, "led: brightness: Failed to open 'brightness': %s", strerror(errno));
+        syslog(LOG_ERR, "led: brightness: Failed to open %s: %s", buf, strerror(errno));
         return MRAA_ERROR_INVALID_RESOURCE;
     }
 
@@ -59,7 +59,7 @@ mraa_led_get_maxbrightfd(mraa_led_context dev)
     snprintf(buf, MAX_SIZE, "%s/%s", dev->led_path, "max_brightness");
     dev->max_bright_fd = open(buf, O_RDONLY);
     if (dev->max_bright_fd == -1) {
-        syslog(LOG_ERR, "led: max_brightness: Failed to open 'max_brightness': %s", strerror(errno));
+        syslog(LOG_ERR, "led: max_brightness: Failed to open %s: %s", buf, strerror(errno));
         return MRAA_ERROR_INVALID_RESOURCE;
     }
 
@@ -119,7 +119,7 @@ mraa_led_init_internal(const char* led)
 
     snprintf(brightness_path, sizeof(brightness_path), "%s/%s", led_path, "brightness");
     if (access(brightness_path, R_OK | W_OK) != 0) {
-        syslog(LOG_NOTICE, "led: init: current user doesn't have access rights for using LED %s", led_name);
+        syslog(LOG_NOTICE, "led: init: current user doesn't have access rights for %s", brightness_path);
     }
 
     closedir(dir);

--- a/src/uart/uart.c
+++ b/src/uart/uart.c
@@ -262,13 +262,14 @@ mraa_uart_init_raw(const char* path)
         status = MRAA_ERROR_NO_RESOURCES;
         goto init_raw_cleanup;
     }
-    dev->path = (char*) calloc(strlen(path)+1, sizeof(char));
+    size_t path_len = strlen(path);
+    dev->path = (char*) calloc(path_len+1, sizeof(char));
     if (dev->path == NULL) {
         syslog(LOG_ERR, "uart: Failed to allocate memory for path");
         status =  MRAA_ERROR_NO_RESOURCES;
         goto init_raw_cleanup;
     }
-    strncpy((char *) dev->path, path, strlen(path));
+    memcpy((char*) dev->path, path, path_len + 1);
 
     if (IS_FUNC_DEFINED(dev, uart_init_raw_replace)) {
         status = dev->advance_func->uart_init_raw_replace(dev, path);

--- a/src/x86/up.c
+++ b/src/x86/up.c
@@ -22,7 +22,7 @@ mraa_up_set_pininfo(mraa_board_t* board, int mraa_index, char* name, mraa_pincap
 {
     if (mraa_index < board->phy_pin_count) {
         mraa_pininfo_t* pin_info = &board->pins[mraa_index];
-        strncpy(pin_info->name, name, MRAA_PIN_NAME_SIZE);
+        strncpy(pin_info->name, name, MRAA_PIN_NAME_SIZE - 1);
         pin_info->capabilities = caps;
         if (caps.gpio) {
             pin_info->gpio.pinmap = sysfs_pin;

--- a/src/x86/up2.c
+++ b/src/x86/up2.c
@@ -40,7 +40,7 @@ mraa_up2_set_pininfo(mraa_board_t* board, int mraa_index, char* name,
 {
     if (mraa_index < board->phy_pin_count) {
         mraa_pininfo_t* pin_info = &board->pins[mraa_index];
-        strncpy(pin_info->name, name, MRAA_PIN_NAME_SIZE);
+        strncpy(pin_info->name, name, MRAA_PIN_NAME_SIZE-1);
         pin_info->capabilities = caps;
         if (caps.gpio) {
             pin_info->gpio.pinmap = sysfs_pin;

--- a/src/x86/up_xtreme.c
+++ b/src/x86/up_xtreme.c
@@ -37,7 +37,7 @@ mraa_upxtreme_set_pininfo(mraa_board_t* board, int mraa_index, char* name,
 {
     if (mraa_index < board->phy_pin_count) {
         mraa_pininfo_t* pin_info = &board->pins[mraa_index];
-        strncpy(pin_info->name, name, MRAA_PIN_NAME_SIZE);
+        strncpy(pin_info->name, name, MRAA_PIN_NAME_SIZE-1);
         pin_info->capabilities = caps;
         if (caps.gpio) {
             pin_info->gpio.pinmap = sysfs_pin;

--- a/tools/mraa-gpio.c
+++ b/tools/mraa-gpio.c
@@ -162,6 +162,7 @@ gpio_isr_stop(struct gpio_source* gpio_info)
 int
 main(int argc, char** argv)
 {
+    int retval = 0;
     if (argc == 1) {
         print_command_error();
     }
@@ -177,10 +178,13 @@ main(int argc, char** argv)
             if (argc == 4) {
                 int pin = atoi(argv[2]);
                 mraa_boolean_t rawmode = strcmp(argv[1], "setraw") == 0;
-                if (gpio_set(pin, atoi(argv[3]), rawmode) != MRAA_SUCCESS)
+                if (gpio_set(pin, atoi(argv[3]), rawmode) != MRAA_SUCCESS) {
                     fprintf(stdout, "Could not initialize gpio %d\n", pin);
+                    retval = 1;
+                }
             } else {
                 print_command_error();
+                retval = 2;
             }
         } else if ((strcmp(argv[1], "get") == 0) || (strcmp(argv[1], "getraw") == 0)) {
             if (argc == 3) {
@@ -191,9 +195,11 @@ main(int argc, char** argv)
                     fprintf(stdout, "Pin %d = %d\n", pin, level);
                 } else {
                     fprintf(stdout, "Could not initialize gpio %d\n", pin);
+                    retval = 1;
                 }
             } else {
                 print_command_error();
+                retval = 2;
             }
         } else if (strcmp(argv[1], "monitor") == 0) {
             if (argc == 3) {
@@ -211,13 +217,16 @@ main(int argc, char** argv)
                     gpio_isr_stop(&gpio_info);
                 } else {
                     fprintf(stdout, "Failed to register ISR for pin %d\n", pin);
+                    retval = 3;
                 }
             } else {
                 print_command_error();
+                retval = 2;
             }
         } else {
             print_command_error();
+            retval = 2;
         }
     }
-    return 0;
+    return retval;
 }

--- a/tools/mraa-gpio.c
+++ b/tools/mraa-gpio.c
@@ -212,7 +212,9 @@ main(int argc, char** argv)
                     char aux = 0;
                     do {
                         fflush(stdin);
-                        fscanf(stdin, "%c", &aux);
+                        int ret = fscanf(stdin, "%c", &aux);
+                        if (ret == EOF)
+                            perror("fscanf");
                     } while (aux != '\n');
                     gpio_isr_stop(&gpio_info);
                 } else {

--- a/tools/mraa-i2c.c
+++ b/tools/mraa-i2c.c
@@ -228,7 +228,9 @@ run_interactive_mode()
         char* arg;
         argv[0] = "mraa-i2c";
         fprintf(stdout, "Command: ");
-        fgets(command, 80, stdin);
+        char *p = fgets(command, 80, stdin);
+        if (!p || !*p)
+            return;
         command[strlen(command) - 1] = 0;
         if (strncmp(command, "q", strlen("q") + 1) == 0)
             return;


### PR DESCRIPTION
mraa-gpio: return proper error codes, because the permissions might be missing. /dev/class/gpio has now new nested symlinks which are not easily chgrp -R's, and then we want to fallback to sudo mraa-gpio.

led: print full brightness device paths on errors
