### PR TITLE
cmake: bump minimum version to address a deprecation warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,9 @@
-cmake_minimum_required (VERSION 2.8.11)
+cmake_minimum_required (VERSION 3.22)
 project (mraa C)
 
 FIND_PACKAGE (Threads REQUIRED)
 
-if (CMAKE_VERSION VERSION_LESS "3.1")
-  if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
-    set (CMAKE_C_FLAGS "-std=gnu99 ${CMAKE_C_FLAGS}")
-  endif ()
-else ()
-  set (CMAKE_C_STANDARD 99)
-endif ()
+set (CMAKE_C_STANDARD 99)
 
 option (BUILDCPP "Enable C++ (needed by FTDI4222 and tests)" ON)
 


### PR DESCRIPTION
This fixes the following warning shown while configuring:
```
[cmake] CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
[cmake] Compatibility with CMake < 3.10 will be removed from a future version of
[cmake] CMake.
```

We don't have a clearly defined supported distro/versions list, so I took Ubuntu 22.04 as arguably the oldest one we'd want to support for the reference point. It has CMake 3.22, released in July 2022. Other opinions on the choice of version are welcome.

There are additional warnings regarding policy 00148 (related to Python search logic), but I'll tackle those later - they may be a bit more involved and I want to setup build/test workflow first.